### PR TITLE
Removed thrown error

### DIFF
--- a/src/Model/Resolver/WishlistItemsResolver.php
+++ b/src/Model/Resolver/WishlistItemsResolver.php
@@ -114,7 +114,7 @@ class WishlistItemsResolver implements ResolverInterface
         array $args = null
     ) {
         if (!isset($value['model'])) {
-            throw new LocalizedException(__('Missing key "model" in Wishlist value data'));
+            return null;
         }
 
         /** @var Wishlist $wishlist */


### PR DESCRIPTION
**Issue:**
When creating a new customer profile there is no wishlist associated with that user yet. This means that an internal server error is thrown when user is logged in and calling the wishlist query.

