### PR TITLE
#1877 support grouped products in wishlist

### DIFF
--- a/src/Model/Resolver/WishlistItemsResolver.php
+++ b/src/Model/Resolver/WishlistItemsResolver.php
@@ -24,6 +24,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GroupedProduct\Model\Product\Type\Grouped;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Wishlist\Model\Item;
@@ -138,6 +139,16 @@ class WishlistItemsResolver implements ResolverInterface
             $wishlistProductId = $itemProductIds[$wishlistItemId];
             $itemProduct = $wishlistProducts[$wishlistProductId];
 
+            $productOptions = [];
+            if($wishlistItem->getProduct()->getTypeId() == Grouped::TYPE_CODE){
+                foreach($wishlistItem->getBuyRequest()['super_group'] as $id => $qty){
+                    $productOptions['grouped_product_qty'][] = [
+                        'id' => $id,
+                        'qty' => $qty
+                    ];
+                }
+            }
+
             $data[] = [
                 'id' => $wishlistItemId,
                 'qty' => $wishlistItem->getData('qty'),
@@ -145,7 +156,8 @@ class WishlistItemsResolver implements ResolverInterface
                 'description' => $wishlistItem->getDescription(),
                 'added_at' => $wishlistItem->getAddedAt(),
                 'model' => $wishlistItem,
-                'product' => $itemProduct
+                'product' => $itemProduct,
+                'product_options' => $productOptions
             ];
         }
 

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -42,4 +42,14 @@ extend type WishlistOutput {
 
 extend type WishlistItem {
     sku: ID @doc(description: "The wish list item's SKU")
+    product_options: WishlistProductOptions @doc(description: "Set of additional options specific for product type")
+}
+
+type WishlistProductOptions {
+    grouped_product_qty: [WishlistGroupedProductQtyOption] @doc(description: "Grouped products only: mapping between simple product and it's quantity")
+}
+
+type WishlistGroupedProductQtyOption {
+    id: Int @doc(description: "ID of the simple product")
+    qty: Int @doc(description: "Quantity for the simple product")
 }


### PR DESCRIPTION
Adding support for grouped product quantities in wishlist: https://github.com/scandipwa/scandipwa/issues/1877

Includes the following changes:
- parse product ids and quantities from `s_saveWishlistItem` GQL request and save to DB
- read saved product ids and quantities from DB when fetching wishlist data (`s_wishlist` request)

Related PRs: https://github.com/scandipwa/scandipwa/pull/2301 and https://github.com/scandipwa/quote-graphql/pull/64

### As discussed with @lianastaskevica: it turned out that the changes @riha112 made under https://github.com/scandipwa/scandipwa/issues/1876 task are supposed to include the same functionality. If PR for #1876, is successfully merged, merging this PR is not required. Please review the changes, and leave comments for me to take into account in the future. The PR itself will be cancelled after that.