### PR TITLE
#2305 not all configuration being added into cart for configurable product

### DIFF
--- a/src/Model/Resolver/MoveWishlistToCart.php
+++ b/src/Model/Resolver/MoveWishlistToCart.php
@@ -122,7 +122,7 @@ class MoveWishlistToCart implements ResolverInterface
         $itemsCollection = $wishlist->getItemCollection();
 
         foreach ($itemsCollection as $item) {
-            $product = $item->getProduct();
+            $product = clone $item->getProduct();
             $superAttribute = $item->getBuyRequest()->getSuperAttribute();
 
             $items[$product->getSku()] = [


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2305

The second product configuration is actually being added to cart, but is written to DB incorrectly, which causes the issue.

What we get as a result of scenario described (table `quote_item`):

<img width="524" alt="DBeaver+7 3 1+-+quote_item+2021-03-22+10-33-17" src="https://user-images.githubusercontent.com/79456428/111956406-cd41d480-8afb-11eb-89a4-488ba8cd40a1.png">
 
What we should get (the same scenario performed in Luma, where there is no such issue):

<img width="520" alt="DBeaver 7 3 1 - quote_item 2021-03-22 10-37-54" src="https://user-images.githubusercontent.com/79456428/111956574-fbbfaf80-8afb-11eb-943e-27ed50f10dfb.png">

What leads to the issue: `_customOptions` of a `$product` variable are being overwritten each loop iteration (when iterating `$itemsCollection`), as there is reference to the same object in each `$product`, and the object is being modified. Copying `$product` prevents its contents from being modified during the next loop iterations. 
