### PR TITLE
#2956 Output error messages for configurable products on add all to cart

### DIFF
--- a/src/Model/Resolver/MoveWishlistToCart.php
+++ b/src/Model/Resolver/MoveWishlistToCart.php
@@ -21,6 +21,7 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\DataObject;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
@@ -128,7 +129,7 @@ class MoveWishlistToCart implements ResolverInterface
         }
 
         if (count($errors) > 0) {
-            throw new \Exception(json_encode($errors));
+            throw new GraphQlInputException(__(json_encode($errors)));
         }
 
         try {


### PR DESCRIPTION
Original issue: https://github.com/scandipwa/scandipwa/issues/2956

In this PR:
* Instead of outputting error only for one product added so that all products are checked
* Changed error message to match Magento style error messages (_had to use GraphQlInputException with Phrase so that when returning graphql response the data is stored in correct location_) 