### PR TITLE
[3480] Grouped product support for wishlist

### DIFF
--- a/src/Model/Resolver/WishlistItemsResolver.php
+++ b/src/Model/Resolver/WishlistItemsResolver.php
@@ -254,7 +254,7 @@ class WishlistItemsResolver implements ResolverInterface
 
                 // Magento produce HTML markup as label for files. We need plain name of the file instead.
                 foreach ($options as $index => $option){
-                    if($option['option_type'] === 'file'){
+                    if(isset($option['option_type']) && $option['option_type'] == 'file'){
                         $options[$index]['value'] = $option['print_value'];
                     }
                 }


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3480

**Problem:**
* Not all options have `option_type`, (example is grouped product), thus when fetching wishlist data that contains grouped items error msg is returned

**In this PR:**
* Added check got `option_type`