### PR TITLE
[3478] all selected bundle options are saved to DB

### DIFF
--- a/src/Model/FileSupport/BuyRequest/BundleDataProvider.php
+++ b/src/Model/FileSupport/BuyRequest/BundleDataProvider.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/wishlist-graphql
+ * @link    https://github.com/scandipwa/wishlist-graphql
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\WishlistGraphQl\Model\FileSupport\BuyRequest;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Wishlist\Model\Wishlist\BuyRequest\BuyRequestDataProviderInterface;
+use Magento\Wishlist\Model\Wishlist\Data\WishlistItem;
+
+/**
+ * Data provider for bundle product buy requests
+ */
+class BundleDataProvider implements BuyRequestDataProviderInterface
+{
+    private const PROVIDER_OPTION_TYPE = 'bundle';
+
+    /**
+     * @inheritdoc
+     *
+     * @phpcs:disable Magento2.Functions.DiscouragedFunction
+     */
+    public function execute(WishlistItem $wishlistItem, ?int $productId): array
+    {
+        $bundleOptionsData = [];
+
+        foreach ($wishlistItem->getSelectedOptions() as $optionData) {
+            $optionData = \explode('/', base64_decode($optionData->getId()));
+
+            if ($this->isProviderApplicable($optionData) === false) {
+                continue;
+            }
+
+            [$optionType, $optionId, $optionValueId, $optionQuantity] = $optionData;
+
+            if ($optionType == self::PROVIDER_OPTION_TYPE) {
+                $bundleOptionsData['bundle_option'][$optionId][] = $optionValueId;
+                $bundleOptionsData['bundle_option_qty'][$optionId][] = $optionQuantity;
+            }
+        }
+        //for bundle options with custom quantity
+        foreach ($wishlistItem->getEnteredOptions() as $option) {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            $optionData = \explode('/', base64_decode($option->getUid()));
+
+            if ($this->isProviderApplicable($optionData) === false) {
+                continue;
+            }
+            $this->validateInput($optionData);
+
+            [$optionType, $optionId, $optionValueId] = $optionData;
+            if ($optionType == self::PROVIDER_OPTION_TYPE) {
+                $optionQuantity = $option->getValue();
+                $bundleOptionsData['bundle_option'][$optionId][] = $optionValueId;
+                $bundleOptionsData['bundle_option_qty'][$optionId][] = $optionQuantity;
+            }
+        }
+
+        return $bundleOptionsData;
+    }
+
+    /**
+     * Validates the provided options structure
+     *
+     * @param array $optionData
+     * @throws LocalizedException
+     */
+    private function validateInput(array $optionData): void
+    {
+        if (count($optionData) !== 4) {
+            $errorMessage = __('Wrong format of the entered option data');
+            throw new LocalizedException($errorMessage);
+        }
+    }
+
+    /**
+     * Checks whether this provider is applicable for the current option
+     *
+     * @param array $optionData
+     *
+     * @return bool
+     */
+    private function isProviderApplicable(array $optionData): bool
+    {
+        return $optionData[0] === self::PROVIDER_OPTION_TYPE;
+    }
+}

--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -10,6 +10,7 @@
         <arguments>
             <argument name="providers" xsi:type="array">
                 <item name="customizable_option" xsi:type="object">ScandiPWA\WishlistGraphQl\Model\FileSupport\BuyRequest\CustomizableOptionDataProvider</item>
+                <item name="bundle" xsi:type="object">ScandiPWA\WishlistGraphQl\Model\FileSupport\BuyRequest\BundleDataProvider</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
**Original issue:**
* Fixes: https://github.com/scandipwa/scandipwa/issues/3478#issue-1016102356

**Problem:**
* All selected check-boxes are being set on same Id after decoding (only last one is saved to DB)

**In this PR:**
* Set bundle type data to accept an array of same decoded Id option.
